### PR TITLE
Update get posters route

### DIFF
--- a/src/controllers/organization.controller.ts
+++ b/src/controllers/organization.controller.ts
@@ -17,7 +17,10 @@ class organizationController {
 
   getEventPosters = async (req: Request, res: Response) => {
     try {
-      const events = await OrganizationService.getEventPosters();
+      const events = await Promise.all([
+        OrganizationService.getEventPosters(true),
+        OrganizationService.getEventPosters(),
+      ]);
       res.status(200).send(events);
     } catch (error: any) {
       res.status(error.statusCode || 500).send({ message: error.message });

--- a/src/services/organization.service.ts
+++ b/src/services/organization.service.ts
@@ -13,8 +13,8 @@ class organizationService {
       .limit(5);
   };
 
-  getEventPosters = async () => {
-    return await EventModel.find({})
+  getEventPosters = async (isPublished = false) => {
+    return await EventModel.find({ isPublished })
       .select("posterImage slug name description ")
       .lean();
   };


### PR DESCRIPTION
This pull request updates the `organizationController` and `organizationService` to enhance the handling of event posters by supporting filtering based on publication status. The changes improve functionality by allowing the retrieval of both published and unpublished event posters.

Enhancements to event poster handling:

* [`src/controllers/organization.controller.ts`](diffhunk://#diff-16bdaa19d983ceeef570dc430528f1772dc3f67f7c0757557c710161fd607624L20-R23): Updated the `getEventPosters` method to fetch both published and unpublished event posters by calling `OrganizationService.getEventPosters` twice—once with the `isPublished` flag set to `true` and once without the flag. The results are combined using `Promise.all`.
* [`src/services/organization.service.ts`](diffhunk://#diff-4db631c7235ed44968d0e795bb14e16b38a96e7ae698ff3d6d599eb51ed620a4L16-R17): Modified the `getEventPosters` method to accept an optional `isPublished` parameter, enabling filtering of event posters based on their publication status.