### PR TITLE
Update get assign ticket route for main image

### DIFF
--- a/src/services/user-ticket.service.ts
+++ b/src/services/user-ticket.service.ts
@@ -9,7 +9,7 @@ class userTicketService {
     })
       .populate({
         path: "event",
-        select: "name startDate",
+        select: "name startDate mainImage",
       })
       .populate({
         path: "venue",
@@ -33,6 +33,7 @@ class userTicketService {
           _id: ticket.event?._id,
           name: ticket.event?.name,
           startDate: ticket.event?.startDate,
+          posterImage: ticket.event?.mainImage,
         },
         venue: {
           _id: venue?._id,


### PR DESCRIPTION
This pull request makes a small enhancement to the `userTicketService` in `src/services/user-ticket.service.ts` by including the event's main image in the ticket details returned to the user.

- The `populate` call for the `event` now includes the `mainImage` field, allowing the main image to be fetched along with the event name and start date.
- The returned ticket details now include a new `posterImage` property, which is set to the event's `mainImage`.